### PR TITLE
Small lints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 extern crate notify;
 extern crate git2;
 
-use std::sync::mpsc::channel;
-use std::process::Command;
 use std::env;
-use std::thread;
+use std::process::Command;
+use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 use notify::{RecommendedWatcher, Watcher};
 use git2::Repository;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
 
     let mut args = Vec::new();
 
-    while let Some(arg) = argv.next() {
+    for arg in argv {
         args.push(arg)
     }
 


### PR DESCRIPTION
This PR has some lints suggested by [clippy](https://github.com/Manishearth/rust-clippy).

One extra suggestion that is not included on this PR is to use the `AtomicBool`, or just a `Mutex<()>` if what is needed is locking only.
https://github.com/Manishearth/rust-clippy/wiki#mutex_atomic